### PR TITLE
Remove GitHub Jobs as it is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A collection of awesome places to job hunt for people in tech. Compiled resource
 
 ## Popular Sites to Job Hunt
 * AngelList - https://angel.co
-* GitHub: http://jobs.github.com
 * Mashable: http://jobs.mashable.com/jobs
 * Indeed: http://indeed.com
 * StackOverflow: http://stackoverflow.com/jobs


### PR DESCRIPTION
GitHub Jobs is deprecated! New jobs will not be posted from May 19, 2021. It will shut down entirely on August 19, 2021.